### PR TITLE
Pad more 128 bytes when necessary to complete a 256 bytes sector

### DIFF
--- a/rffe_lib.py
+++ b/rffe_lib.py
@@ -151,6 +151,7 @@ class RFFEControllerBoard:
             self.board_socket.send(bytearray.fromhex("20 00 02 09 01"))
             temp = self.board_socket.recv(1024)
 
+            bytes_written = 0
             while True:
                 data = f.read(128)
                 if (not data):
@@ -158,6 +159,12 @@ class RFFEControllerBoard:
                 elif (len(data) < 128):
                     data = data + (b"\xFF" * (128 - len(data)))
                 self.board_socket.send(bytearray.fromhex("20 00 81 0A") + data)
+                temp = self.board_socket.recv(1024)
+                bytes_written += len(data)
+
+            #If the last sector was only half written, send more 128 bytes
+            if (bytes_written % 256) != 0:
+                self.board_socket.send(bytearray.fromhex("20 00 81 0A") + (b"\xFF" * 128))
                 temp = self.board_socket.recv(1024)
 
             self.board_socket.send(bytearray.fromhex("20 00 02 09 02"))


### PR DESCRIPTION
As the firmware image is transferred in blocks of 128 bytes, and the
sector size is 256 bytes, sometimes the firmware image may be divided
in a odd number of 128 bytes blocks, preventing the last flash sector
of been written. This causes firmware corruption.

I've added a check to ensure that a even number of 128 bytes blocks
are always sent.